### PR TITLE
Fix segmentInfos replace doesn't set userData

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -1008,6 +1008,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   void replace(SegmentInfos other) {
     rollbackSegmentInfos(other.asList());
     lastGeneration = other.lastGeneration;
+    userData = other.userData;
   }
 
   /** Returns sum of all segment's maxDocs. Note that this does not include deletions */


### PR DESCRIPTION
### Description

Found that the [replace method](https://github.com/qcri/solr-6/blob/master/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java#L875-L878) doesn't set `userData` with the new user data from `other`. 

Existing:
```
  void replace(SegmentInfos other) {
    rollbackSegmentInfos(other.asList());
    lastGeneration = other.lastGeneration;
  }
```

Fix:
```
  void replace(SegmentInfos other) {
    rollbackSegmentInfos(other.asList());
    lastGeneration = other.lastGeneration;
    userData = other.userData;
  }
```

### Version and environment details

Lucene version 9.7